### PR TITLE
Replace isatty() with github.com/robertkrimen/isatty

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.14
 require (
 	github.com/0xef53/go-qmp/v2 v2.0.1
 	github.com/0xef53/liner v0.0.0-20160615113019-8975875355a8
+	github.com/robertkrimen/isatty v0.0.0-20130325233602-e10c441e3f8c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,3 +3,5 @@ github.com/0xef53/go-qmp/v2 v2.0.1 h1:gICtJ0eplbHfxafQix3pqFLM8t3Db29GhhtyYoNhjN
 github.com/0xef53/go-qmp/v2 v2.0.1/go.mod h1:kqJLp1jcRUdsFE9WPBhPGy6r+/NOT4O7MyPImF9wD8A=
 github.com/0xef53/liner v0.0.0-20160615113019-8975875355a8 h1:+Q0uzJh6lFIdOfzdRrW65KWpqL6YExJr1A0WHjFhOQs=
 github.com/0xef53/liner v0.0.0-20160615113019-8975875355a8/go.mod h1:+J9ttMBwY2NxF2l5nqTkvlVltdCa3iVIZuWRi9vY1dU=
+github.com/robertkrimen/isatty v0.0.0-20130325233602-e10c441e3f8c h1:vohwaDqkxaWd67Faev9nHq2G4q2jHmFdpb4Y8m/SGQY=
+github.com/robertkrimen/isatty v0.0.0-20130325233602-e10c441e3f8c/go.mod h1:YkNdk/V1G+bh9l1esg4xXX5WkmWM0T5dQqvYjqpIuw0=

--- a/qmp-shell.go
+++ b/qmp-shell.go
@@ -12,13 +12,12 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 	"unicode"
-	"unsafe"
 
 	"github.com/0xef53/go-qmp/v2"
 	"github.com/0xef53/liner"
+    "github.com/robertkrimen/isatty"
 )
 
 var (
@@ -372,21 +371,6 @@ type Shell interface {
 	Close()
 }
 
-func isatty() bool {
-	var termios syscall.Termios
-
-	_, _, err := syscall.Syscall6(
-		syscall.SYS_IOCTL,
-		os.Stdin.Fd(),
-		uintptr(syscall.TCGETS),
-		uintptr(unsafe.Pointer(&termios)),
-		0,
-		0,
-		0,
-	)
-	return err == 0
-}
-
 func init() {
 	flag.Usage = printUsage
 }
@@ -419,7 +403,7 @@ func main() {
 	}
 	defer shell.Close()
 
-	if !isatty() {
+	if !isatty.Check(os.Stdin.Fd()) {
 		r := bufio.NewReader(os.Stdin)
 		cmdline, err := r.ReadString('\n')
 		if err != nil {


### PR DESCRIPTION
This makes qmp-shell compatible with Darwin (i.e. MacOS).